### PR TITLE
Fix hashCode null user handling

### DIFF
--- a/src/main/java/br/com/drinkwater/hydrationtracking/model/WaterIntake.java
+++ b/src/main/java/br/com/drinkwater/hydrationtracking/model/WaterIntake.java
@@ -151,7 +151,8 @@ public class WaterIntake {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, dateTimeUTC, volume, volumeUnit, user.getId());
+        return Objects.hash(id, dateTimeUTC, volume, volumeUnit,
+                user != null ? user.getId() : null);
     }
 
     @Override

--- a/src/test/java/br/com/drinkwater/hydrationtracking/model/WaterIntakeTest.java
+++ b/src/test/java/br/com/drinkwater/hydrationtracking/model/WaterIntakeTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 
 public final class WaterIntakeTest {
 
@@ -160,14 +161,16 @@ public final class WaterIntakeTest {
     }
 
     @Test
-    public void givenNullUserInWaterIntake_whenHashCode_thenThrowsNullPointerException() {
+    public void givenNullUserInWaterIntake_whenHashCode_thenReturnsHashWithoutUser() {
         // Given a water intake with null user
         WaterIntake waterIntake = new WaterIntake(WATER_INTAKE_ID, DATE_TIME_UTC, VOLUME, VOLUME_UNIT, USER);
         waterIntake.setUser(null);
 
-        // When/Then: hashCode should handle null user
-        assertThatThrownBy(waterIntake::hashCode)
-                .isInstanceOf(NullPointerException.class);
+        // When
+        int expectedHash = Objects.hash(WATER_INTAKE_ID, DATE_TIME_UTC, VOLUME, VOLUME_UNIT, (Long) null);
+
+        // Then
+        assertThat(waterIntake.hashCode()).isEqualTo(expectedHash);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- avoid NullPointerException when calling `WaterIntake.hashCode()` without a user
- update tests for new hashCode behaviour

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6840801f2490832c9a39cc87924067cd