### PR TITLE
Fix date range validator message

### DIFF
--- a/src/main/java/br/com/drinkwater/hydrationtracking/validation/DateRangeValidator.java
+++ b/src/main/java/br/com/drinkwater/hydrationtracking/validation/DateRangeValidator.java
@@ -18,9 +18,9 @@ public class DateRangeValidator implements ConstraintValidator<ValidDateRange, W
             // Disable default constraint violation
             context.disableDefaultConstraintViolation();
 
-            // Add custom message
+            // Add custom message using message key
             context.buildConstraintViolationWithTemplate(
-                            "End date must be equal to or after start date")
+                            "{validation.timerange.start.before.end}")
                     .addPropertyNode("endDate")
                     .addConstraintViolation();
 

--- a/src/test/java/br/com/drinkwater/hydrationtracking/validation/DateRangeValidatorTest.java
+++ b/src/test/java/br/com/drinkwater/hydrationtracking/validation/DateRangeValidatorTest.java
@@ -1,0 +1,55 @@
+package br.com.drinkwater.hydrationtracking.validation;
+
+import br.com.drinkwater.config.TestMessageSourceConfig;
+import br.com.drinkwater.hydrationtracking.dto.WaterIntakeFilterDTO;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig(TestMessageSourceConfig.class)
+@ActiveProfiles("test")
+public class DateRangeValidatorTest {
+
+    @Autowired
+    private Validator validator;
+
+    @Autowired
+    private MessageSource messageSource;
+
+    @Test
+    public void givenStartAfterEnd_whenValidate_thenReturnsLocalizedMessage() {
+        Instant startDate = Instant.now();
+        Instant endDate = startDate.minus(1, ChronoUnit.DAYS);
+
+        WaterIntakeFilterDTO dto = new WaterIntakeFilterDTO(
+                startDate,
+                endDate,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        var violations = validator.validate(dto);
+
+        assertThat(violations).hasSize(1);
+        var violation = violations.iterator().next();
+        String expectedMessage = messageSource.getMessage(
+                "validation.timerange.start.before.end",
+                null,
+                Locale.US
+        );
+        assertThat(violation.getMessage()).isEqualTo(expectedMessage);
+    }
+}


### PR DESCRIPTION
## Summary
- use property key for DateRangeValidator message
- add unit test to confirm the validation message resolves

## Testing
- `mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684081b17484832cbdbc2b76f0deb666